### PR TITLE
FactoryBot省略化設定

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join("spec/fixtures")
 


### PR DESCRIPTION
FactoryBotの省略化するコードを記載
```
RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end
```